### PR TITLE
news: summer 2026 events

### DIFF
--- a/_news/2026/2026-06-01-3022.md
+++ b/_news/2026/2026-06-01-3022.md
@@ -1,0 +1,31 @@
+---
+layout: post
+title: University of Washington PhD Candidate Chu Li Visits EVL
+date: 2026-06-01
+tags: event
+categories: events
+tabs: true
+image: chuli_evl_visit_2026.png-srcw.jpg
+
+---
+
+Chu Li, a final-year PhD candidate in Computer Science &amp; Engineering at the University of Washington, advised by Jon Froehlich and currently a research scientist intern at Adobe, visited the Electronic Visualization Laboratory to present her work. Her research interests span human-computer interaction, human-AI collaboration, urban informatics, and accessible visualization.<br><br>
+Her talk covered her PhD research on making the tools we use to understand, visualize, design, and navigate cities more inclusive. During the visit she also toured EVL&rsquo;s facilities, including the CAVE2 display environment, and the UIC Department of Disability and Human Development, where she saw the Assistive Technology Unit and its custom fabrication lab.<br><br>
+In her own words:<br><br>
+&ldquo;Last week I had the honor of visiting the University of Illinois Chicago to talk about my PhD research on making the tools we use to understand, visualize, design, and navigate cities more inclusive.<br><br>
+Had a wonderful time at the Electronic Visualization Laboratory (EVL)! Thank you Fabio Miranda for the invitation, and many thanks to Yochai Eisenberg, Saeed BoorBoor, Khairi Reda, Luc Renambot, Sajad Askari, and all the faculty and students who came to my talk on the hottest day in Chicago.<br><br>
+Also got to finally meet Yochai Eisenberg in person after four years of collaborating! Thanks for giving me such a thorough tour of the Disability and Human Development Department along with Daniel Cochrane.&rdquo;
+
+![image](/images/chuli_evl_visit_2026.png-srcw.jpg){:style="max-width: 100%"}
+- Caption: Chu Li presenting her PhD research to faculty and students at EVL.
+
+![image](/images/chuli_evl_visit_2026b.png-srcw.jpg){:style="max-width: 100%"}
+- Caption: EVL faculty and students with Chu Li following her talk.
+
+![image](/images/chuli_evl_visit_2026c.png-srcw.jpg){:style="max-width: 100%"}
+- Caption: Touring EVL&rsquo;s CAVE2 display environment.
+
+![image](/images/chuli_evl_visit_2026d.png-srcw.jpg){:style="max-width: 100%"}
+- Caption: The Assistive Technology Unit and custom fabrication lab in the UIC Department of Disability and Human Development.
+
+Link: [https://www.linkedin.com/in/chu-li-crescendo/](https://www.linkedin.com/in/chu-li-crescendo/)

--- a/_news/2026/2026-07-17-3021.md
+++ b/_news/2026/2026-07-17-3021.md
@@ -1,0 +1,34 @@
+---
+layout: post
+title: 'EVL PhD Student Sanjana Srabanti Successfully Defends Her Dissertation'
+date: 2026-07-17
+tags: event
+categories: events
+tabs: true
+image: ssrabanti_phd_2026.png-srcw.jpg
+
+---
+
+Congratulations to Dr. Sanjana Srabanti, who successfully defended her PhD dissertation, &ldquo;Visual Analytics Systems and Grammars for Multivariate Social Variability Research,&rdquo; at the University of Illinois Chicago.<br><br>
+In her own words:<br><br>
+&ldquo;I am officially a Dr.! This milestone represents six years of research, persistence, long nights, difficult deadlines, and many moments of growth. Getting a PhD has been a lifelong dream, but along the way I learned that this journey is not only about earning a degree. It is about learning how to think independently, ask meaningful questions, build resilience, and keep going even when the path feels uncertain.<br><br>
+I am deeply grateful to my advisors, Dr. Liz Marai and Dr. Fabio Miranda, for their guidance, support, and belief in my work. I am also thankful to my dissertation committee, Dr. Khairi Reda, Dr. Saeed BoorBoor, and Dr. Guadalupe Canahuate, for their time, feedback, and encouragement throughout this process.&rdquo;<br><br>
+Candidate: Sanjana Srabanti<br>
+Committee:<br>
+Dr. G. Elisabeta Marai (chair and advisor)<br>
+Dr. Fabio Miranda (advisor)<br>
+Dr. Khairi Reda<br>
+Dr. Saeed BoorBoor<br>
+Dr. Guadalupe Canahuate<br><br>
+Congratulations from everyone at EVL!
+
+![image](/images/ssrabanti_phd_2026.png-srcw.jpg){:style="max-width: 100%"}
+- Caption: Sanjana Srabanti with her dissertation committee following the defense.
+
+![image](/images/ssrabanti_phd_2026b.png-srcw.jpg){:style="max-width: 100%"}
+- Caption: The defense presented on EVL&rsquo;s display wall, with remote committee members joining online.
+
+![image](/images/ssrabanti_phd_2026c.png-srcw.jpg){:style="max-width: 100%"}
+- Caption: Sanjana Srabanti presenting her dissertation work.
+
+Link: [https://www.linkedin.com/in/sanjana-srabanti-3b958b12a/](https://www.linkedin.com/in/sanjana-srabanti-3b958b12a/)

--- a/_news/2026/2026-07-20-3019.md
+++ b/_news/2026/2026-07-20-3019.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: EVL Hosts the Sage Grande Summer of AI Hackathon
+date: 2026-07-20
+tags: event
+categories: events
+tabs: true
+image: sage_summer_ai_hackathon_2026.png-srcw.jpg
+
+---
+
+The Electronic Visualization Laboratory (EVL) at the University of Illinois Chicago hosted the <a href="https://sagecontinuum.org/docs/events/2026-Sage-Summer-Hackathon">Sage Grande: Summer of AI</a> hackathon, a nine-day hands-on camp held July 20&ndash;28, 2026, where graduate students, postdocs, and early-career researchers built and deployed AI at the edge on live Sage nodes.<br><br>
+Participants worked directly with Sage Grande Testbed hardware &mdash; nodes equipped with cameras, microphones, lidar, and other environmental sensors &mdash; running their own machine learning models on the devices themselves rather than shipping raw data to the cloud. Over the course of the camp, teams moved from an introduction to the testbed and its cyberinfrastructure through model development, on-node deployment, and validation against live sensor streams. EVL&rsquo;s Cyber-Commons display wall was used throughout to share code, dashboards, sensor imagery, and results side by side during working sessions.<br><br>
+Each team closed the camp by delivering a set of artifacts: a five-minute presentation on July 27 and 28, a project overview for the Sage website, an edge computing application where applicable, a poster, and a review of the experience of building for the edge.<br><br>
+The Sage Grande Testbed is an NSF-funded cyberinfrastructure for AI@Edge computing, harnessing AI to address important science questions. For more information, visit <a href="https://sagecontinuum.org/">https://sagecontinuum.org/</a>.
+
+![image](/images/sage_summer_ai_hackathon_2026.png-srcw.jpg){:style="max-width: 100%"}
+- Caption: Sage Grande Testbed overview session in EVL&rsquo;s Cyber-Commons, opening the Summer of AI hackathon.
+
+![image](/images/sage_summer_ai_hackathon_2026b.png-srcw.jpg){:style="max-width: 100%"}
+- Caption: Hackathon participants working alongside Sage nodes and their sensors during the camp.
+
+Link: [https://sagecontinuum.org/docs/events/2026-Sage-Summer-Hackathon](https://sagecontinuum.org/docs/events/2026-Sage-Summer-Hackathon)<br><br>
+\#AI \#EdgeComputing \#SageContinuum \#UIC \#EVL

--- a/_news/2026/2026-07-24-3020.md
+++ b/_news/2026/2026-07-24-3020.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: 'Sage Grande Summer of AI&#58; Students Bring a New Weather Sensor onto a Sage Node'
+date: 2026-07-24
+tags: event
+categories: events
+tabs: true
+image: sage_summer_ai_weather_sensor_2026.png-srcw.jpg
+
+---
+
+<a href="https://sagecontinuum.org/docs/events/2026-Sage-Summer-Hackathon">Sage Grande: Summer of AI</a> reached its halfway point at the Electronic Visualization Laboratory. Since Monday, students and postdocs have been deploying AI to real edge nodes.<br><br>
+University of Illinois Chicago students Michael Cortez, DongJune Park, Samin Sohrabi, Alejandra Rios, Mahsa Alishiri, and Elizabeth Cardoso spent the week bringing a new weather sensor onto a Sage node: wiring and power, serial communication, a containerized app, and calibrated measurements published with timestamps and units to the Sage data stream. Real code, real nodes, real deployment problems.<br><br>
+The team presented their &ldquo;Edge based Weather Station Sensor&rdquo; project on EVL&rsquo;s Cyber-Commons display wall, work carried out with EVL, Sage, and Argonne National Laboratory.
+
+![image](/images/sage_summer_ai_weather_sensor_2026.png-srcw.jpg){:style="max-width: 100%"}
+- Caption: UIC students present their edge-based weather station sensor project during the Sage Grande: Summer of AI hackathon at EVL.
+
+Link: [https://sagecontinuum.org/docs/events/2026-Sage-Summer-Hackathon](https://sagecontinuum.org/docs/events/2026-Sage-Summer-Hackathon)<br><br>
+\#EdgeComputing \#AI \#UIC \#EVL \#NSF

--- a/_news/2026/2026-07-29-3023.md
+++ b/_news/2026/2026-07-29-3023.md
@@ -1,0 +1,29 @@
+---
+layout: post
+title: EVL Hosts the NSF Sage All-Hands and Advisory Committee Meetings
+date: 2026-07-29
+tags: event
+categories: events
+tabs: true
+image: sage_ahm26_evl.png-srcw.jpg
+
+---
+
+EVL hosted the NSF Sage leadership team, including EVL director Mike Papka, for their annual All-Hands Meeting (AHM) and Advisory Committee meeting, held July 29&ndash;31, 2026 in EVL&rsquo;s Arcade room. For three days the teams used EVL&rsquo;s facilities to brainstorm and discuss their AI at the edge project and its deployment.<br><br>
+The meetings continued directly from the <a href="https://sagecontinuum.org/docs/events/2026-Sage-Summer-Hackathon">Sage Grande: Summer of AI</a> hackathon held at EVL the previous week, carrying the students&rsquo; edge deployment work into the leadership team&rsquo;s planning discussions.<br><br>
+Sessions covered the Sage Grande Testbed architecture and the goals set out in the original proposal, along with domain science applications ranging from AI for precision irrigation prescriptions in agriculture to the Change Hawai&lsquo;i project. Throughout the meetings, the Arcade display wall was used to lay out slides, dashboards, participant introductions, and project imagery side by side, so the group could work across the full breadth of the project at once.<br><br>
+For more information, see the <a href="https://sagecontinuum.org/team/leadership">Sage leadership team</a> and the <a href="https://sagecontinuum.org/">Sage project</a>.
+
+![image](/images/sage_ahm26_evl.png-srcw.jpg){:style="max-width: 100%"}
+- Caption: A Sage Grande Testbed architecture overview presented on the Arcade display wall.
+
+![image](/images/sage_ahm26_evl_b.png-srcw.jpg){:style="max-width: 100%"}
+- Caption: The Change Hawai&lsquo;i project presented during the All-Hands Meeting.
+
+![image](/images/sage_ahm26_evl_c.png-srcw.jpg){:style="max-width: 100%"}
+- Caption: A domain science session on using AI to support precision irrigation prescriptions in agriculture.
+
+![image](/images/sage_ahm26_evl_d.png-srcw.jpg){:style="max-width: 100%"}
+- Caption: The AHM26 canvas on EVL&rsquo;s Arcade display wall, combining participant introductions, project photos, and outcome summaries.
+
+Link: [https://sagecontinuum.org/](https://sagecontinuum.org/)

--- a/_news/2026/2026-07-29-3023.md
+++ b/_news/2026/2026-07-29-3023.md
@@ -11,7 +11,7 @@ image: sage_ahm26_evl.png-srcw.jpg
 
 EVL hosted the NSF Sage leadership team, including EVL director Mike Papka, for their annual All-Hands Meeting (AHM) and Advisory Committee meeting, held July 29&ndash;31, 2026 in EVL&rsquo;s Arcade room. For three days the teams used EVL&rsquo;s facilities to brainstorm and discuss their AI at the edge project and its deployment.<br><br>
 The meetings continued directly from the <a href="https://sagecontinuum.org/docs/events/2026-Sage-Summer-Hackathon">Sage Grande: Summer of AI</a> hackathon held at EVL the previous week, carrying the students&rsquo; edge deployment work into the leadership team&rsquo;s planning discussions.<br><br>
-Sessions covered the Sage Grande Testbed architecture and the goals set out in the original proposal, along with domain science applications ranging from AI for precision irrigation prescriptions in agriculture to the Change Hawai&lsquo;i project. Throughout the meetings, the Arcade display wall was used to lay out slides, dashboards, participant introductions, and project imagery side by side, so the group could work across the full breadth of the project at once.<br><br>
+Throughout the meetings, the Arcade display wall was used to lay out slides, dashboards, participant introductions, and project imagery side by side, so the group could work across the full breadth of the project at once.<br><br>
 For more information, see the <a href="https://sagecontinuum.org/team/leadership">Sage leadership team</a> and the <a href="https://sagecontinuum.org/">Sage project</a>.
 
 ![image](/images/sage_ahm26_evl.png-srcw.jpg){:style="max-width: 100%"}


### PR DESCRIPTION
Five new news posts covering EVL activity in summer 2026.

| Post | Date | Subject |
|---|---|---|
| 3022 | 2026-06-01 | Chu Li (University of Washington) visits EVL |
| 3021 | 2026-07-17 | Sanjana Srabanti defends her PhD dissertation |
| 3019 | 2026-07-20 | Sage Grande: Summer of AI hackathon at EVL (July 20-28) |
| 3020 | 2026-07-24 | UIC students bring a new weather sensor onto a Sage node |
| 3023 | 2026-07-29 | NSF Sage All-Hands and Advisory Committee meetings at EVL |

## Before merging

- **Images are not in this PR.** The 14 images referenced by these posts still need to be uploaded to the server's `/images/` directory, or the posts will render with broken images.
- **Post 3022 date is uncertain.** The source text gave "June 1st", but the photo metadata is dated 2026-07-13 and the quoted text says "last week", which would place the visit around July 6-10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)